### PR TITLE
docs: update commit message convention

### DIFF
--- a/pages/development/processes/pull-request.mdx
+++ b/pages/development/processes/pull-request.mdx
@@ -20,6 +20,10 @@
 
 ## Commit
 ### Commit message
+The commit message should have less than 72 characters in the first line and should be in the present tense.
+
+The first line should be a concise summary of the commit.
+
 The commit message should be structured as follows:
 
 ```


### PR DESCRIPTION
## What
Add convention about the content and the maximum length of the commit message

## Why
To make it easier to track commits
https://dev.to/noelworden/improving-your-commit-message-with-the-50-72-rule-3g79
